### PR TITLE
Add YAML config example and support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,27 @@
 # wos-llm-geo
 Extract region and geolocation from WoS data using LLMs + Google Maps API
+
+## Configuration
+
+The application uses a YAML configuration file. A sample `config.yaml` is
+included in the repository:
+
+```yaml
+start_index: 0
+llm_batch_size: 20
+geo_batch_size: 10
+```
+
+Create your own file or modify these values as needed. Pass the path to your
+custom configuration with the `--config` option:
+
+## Usage
+
+Run the main script and optionally specify a configuration file or override
+individual options from the command line:
+
+```bash
+python main.py --config myconfig.yaml --llm-batch-size 5
+```
+
+Command line arguments take precedence over the values in the YAML file.

--- a/config.yaml
+++ b/config.yaml
@@ -1,0 +1,3 @@
+start_index: 0
+llm_batch_size: 20
+geo_batch_size: 10

--- a/main.py
+++ b/main.py
@@ -1,0 +1,92 @@
+"""Main application entry point for WoS LLM geolocation extraction."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from dataclasses import dataclass
+from typing import Any, Dict
+
+import yaml
+
+
+@dataclass
+class Config:
+    """Application configuration."""
+
+    start_index: int = 0
+    llm_batch_size: int = 20
+    geo_batch_size: int = 10
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "Config":
+        """Create a configuration instance from a dictionary."""
+        return cls(
+            start_index=data.get("start_index", cls.start_index),
+            llm_batch_size=data.get("llm_batch_size", cls.llm_batch_size),
+            geo_batch_size=data.get("geo_batch_size", cls.geo_batch_size),
+        )
+
+
+def load_config(path: str) -> Config:
+    """Load configuration from a YAML file."""
+    if not os.path.exists(path):
+        return Config()
+    with open(path, "r", encoding="utf-8") as f:
+        data = yaml.safe_load(f) or {}
+    return Config.from_dict(data)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Process WoS data with LLM and geocoding"
+    )
+    parser.add_argument(
+        "--config",
+        default="config.yaml",
+        help="Path to YAML config file",
+    )
+    parser.add_argument(
+        "--start-index",
+        type=int,
+        help="Override start index from config",
+    )
+    parser.add_argument(
+        "--llm-batch-size",
+        type=int,
+        help="Override LLM batch size from config",
+    )
+    parser.add_argument(
+        "--geo-batch-size",
+        type=int,
+        help="Override geolocation batch size from config",
+    )
+    return parser.parse_args()
+
+
+def merge_config(args: argparse.Namespace, config: Config) -> Config:
+    """Merge command line arguments into a configuration instance."""
+    if args.start_index is not None:
+        config.start_index = args.start_index
+    if args.llm_batch_size is not None:
+        config.llm_batch_size = args.llm_batch_size
+    if args.geo_batch_size is not None:
+        config.geo_batch_size = args.geo_batch_size
+    return config
+
+
+def main() -> None:
+    """Script entry point."""
+    args = parse_args()
+    config = load_config(args.config)
+    config = merge_config(args, config)
+
+    print("Final configuration:")
+    print(f"start_index: {config.start_index}")
+    print(f"llm_batch_size: {config.llm_batch_size}")
+    print(f"geo_batch_size: {config.geo_batch_size}")
+
+
+if __name__ == '__main__':
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pandas
 python-dotenv
 httpx
 tiktoken
+pyyaml


### PR DESCRIPTION
## Summary
- add example `config.yaml`
- implement configuration loading via `yaml.safe_load`
- allow CLI arguments to override YAML settings
- refine configuration logic with dataclass
- document configuration usage
- add `pyyaml` to requirements

## Testing
- `python -m py_compile main.py`


------
https://chatgpt.com/codex/tasks/task_e_686bc01153688331823e9995c50b08f5